### PR TITLE
Add z-index on header-text div, closes #28

### DIFF
--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -64,6 +64,7 @@ h1 {
   height: 20px;
   left: 10px;
   top: 27px;
+  z-index: -1;
 
   @media #{$mobile-only} {
     top: 22px;


### PR DESCRIPTION
From #28 :

>The `header-text` div covers some of the logo you can click to go back to the homepage.
>This affects both the mobile and desktop views. Encountered on Chrome 57 and Firefox 50 on OS X.
>
>I will open a PR shortly to fix.
>
><img width="680" alt="screen shot 2016-12-29 at 16 26 55" src="https://cloud.githubusercontent.com/assets/1525809/21548358/c7065eb2-cde3-11e6-9bcb-10f3b3894745.png">

