### PR TITLE
Add meta tags and apple-touch-icons to make app Apple Web Capable

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -23,18 +23,27 @@
 	<meta property="fb:admins" content="10202985971279760" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
 
-  <link rel="apple-touch-icon" sizes="180x180" href="assets/icons/apple-touch-icon.png">
-  <link rel="icon" type="image/png" href="assets/icons/favicon-32x32.png" sizes="32x32">
-  <link rel="icon" type="image/png" href="assets/icons/favicon-16x16.png" sizes="16x16">
-  <link rel="manifest" href="/manifest.json">
-  <link rel="mask-icon" href="assets/icons/safari-pinned-tab.svg" color="#b92b27">
   <meta name="theme-color" content="#b92b27">
 
   <meta name="msapplication-TileColor" content="#b92b27">
   <meta name="msapplication-TileImage" content="assets/icons/mstile-150x150.png">
   <meta name="msapplication-config" content="assets/icons/browserconfig.xml">
+
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+
+  <link rel="manifest" href="/manifest.json">
+  <link rel="mask-icon" href="assets/icons/safari-pinned-tab.svg" color="#b92b27">
+
+  <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="icon" type="image/png" href="assets/icons/favicon-32x32.png" sizes="32x32">
+  <link rel="icon" type="image/png" href="assets/icons/favicon-16x16.png" sizes="16x16">
+
+  <link rel="apple-touch-icon" sizes="180x180" href="assets/icons/apple-touch-icon.png">
+  <link rel="apple-touch-icon" sizes="120x120" href="assets/icons/apple-touch-icon-120x120.png">
+  <link rel="apple-touch-icon" sizes="152x152" href="assets/icons/apple-touch-icon-152x152.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="assets/icons/apple-touch-icon-180x180.png">
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
This PR adds a few tags to `index.html` to make it behave more like a native app on iOS devices.

![apple-web-capable-app](https://cloud.githubusercontent.com/assets/36491/21632454/9f43a846-d214-11e6-8ace-e2d151112f6c.gif)
